### PR TITLE
New print_entry function

### DIFF
--- a/strax/utils.py
+++ b/strax/utils.py
@@ -243,3 +243,15 @@ def formatted_exception():
         # There was no relevant exception to record
         return ''
     return traceback.format_exc()
+
+def print_entry(d, n=0, show_data=False):
+    """ Print entry number n in human-readable format.
+    Default behavior is to skip the entry 'data' since it clutters output.
+    """
+    # Check what number of spaces required for nice alignment
+    max_len = np.max([len(key) for key in d.dtype.names])
+    el = d[n]
+    for key in d.dtype.names:
+        if (show_data or key != 'data'):
+            print(("{:<%d}: " % max_len).format(key), el[key])
+    return


### PR DESCRIPTION
This one is optional (and I don't mind discarting this change if not needed): it is to print an entry of an np.ndarray in a human-readable format. I have found I need it when reviewing data. If there is anything like pd.DataFrame.head() for numpy arrays, //please// let me know.